### PR TITLE
Grow the patched file if needed

### DIFF
--- a/lipx.py
+++ b/lipx.py
@@ -202,6 +202,10 @@ class IPS(object):
                 rle_size = get_uint16(self.patch_file_obj, a)
                 a += 2
 
+                # Grow the patched file if needed
+                if (offset + rle_size) > len(patched_file):
+                    patched_file += bytearray((offset + rle_size) - len(patched_file))
+
                 # Get repeat byte
                 repeat = self.patch_file_obj[a]
                 a += 1
@@ -213,6 +217,10 @@ class IPS(object):
                         print('> Error - Unable to parse the patch!')
                         sys.exit(1)
             else:
+                # Grow the patched file if needed
+                if (offset + size) > len(patched_file):
+                    patched_file += bytearray((offset + size) - len(patched_file))
+
                 # Normal packet, copy from patch to file
                 for x in range(size):
                     try:


### PR DESCRIPTION
Some patches intentionally result in a larger patched size (for example, the Super Mario Land 2 DX conversion which patches a 512 KiB GB image into a 1 MiB GBC image).

This checks if a segment goes beyond the end of an original file and pads patched_file if needed.