### PR TITLE
Portable shebang

### DIFF
--- a/lipx.py
+++ b/lipx.py
@@ -1,4 +1,4 @@
-#! /bin/python
+#!/usr/bin/env python
 
 import collections
 import os


### PR DESCRIPTION
My environment provides python3 at /usr/bin/python, so this script fails when running with:
`./lipx.py`
This pull request fixes that