### PR TITLE
Inspect mode for viewing IPS patch diffs

### DIFF
--- a/lipx.py
+++ b/lipx.py
@@ -5,6 +5,7 @@ import collections
 import os
 import struct
 import sys
+from textwrap import wrap
 
 VERSION = '1.2'
 _ntuple_diskusage = collections.namedtuple('usage', 'total used free')
@@ -37,13 +38,18 @@ def get_uint24(data, index):
 
 # Helper function to display patch data in INSPECT mode
 def format_patch(offset, size, data, rle=0):
+    PAD = '..'  # byte pad for odd/even byte alignment
+    SEP = ' '   # Hex word separator
     if (offset ^ size) & 1:
         data.append(0)
-        data = data.hex(' ', 2)[:-2]
+        data = data.hex(SEP, 2)[:-2]
     else:
-        data = data.hex(' ', 2)
-    repeat = f' REPEAT x {rle}' if rle else ''
-    return f'{hex(offset)[2:].zfill(6)} ({str(size).zfill(2)}): {"  " * (offset & 1) + data}{repeat}'
+        data = data.hex(SEP, 2)
+    rom_offset = f'{hex(offset)[2:].zfill(6)}'
+    byte_count = f'({str(size|rle)})'
+    repeat = f'{" " * (2 * (~offset & 1))} <REPEAT x {rle}>' if rle else ''
+    patch_data = f'\n{" "*15}'.join(wrap(f'{PAD * (offset & 1) + data}{repeat}', width=40))
+    return f'{rom_offset}{byte_count.rjust(7)}: {patch_data}'
 
 
 class IPS(object):

--- a/lipx.py
+++ b/lipx.py
@@ -8,6 +8,11 @@ import sys
 
 VERSION = '1.2'
 _ntuple_diskusage = collections.namedtuple('usage', 'total used free')
+
+# Modes:
+APPLY = '-a'
+BACKUP_APPLY = '-ab'
+CREATE = '-c'
 INSPECT = 'inspect'
 
 
@@ -79,9 +84,9 @@ class IPS(object):
 
         self._setup_files()
 
-        if self.cmd == '-c':
+        if self.cmd == CREATE:
             ret = self.create_ips()
-        elif self.cmd in ('-a', '-ab', INSPECT):
+        elif self.cmd in (APPLY, BACKUP_APPLY, INSPECT):
             ret = self.apply_ips()
 
         if not ret:
@@ -106,7 +111,7 @@ class IPS(object):
             print('> Not enough space on this disk!\n')
             sys.exit(1)
 
-        if self.cmd == '-ab':
+        if self.cmd == BACKUP_APPLY:
             if not self.__check_disk_space(self.original_file):
                 print('> Not enough space on this disk!\n')
                 sys.exit(1)
@@ -120,7 +125,7 @@ class IPS(object):
                 sys.exit(1)
 
         # File object containing the modified ROM data (To create IPS patch)
-        if self.cmd not in ('-a', '-ab', INSPECT):
+        if self.cmd not in (APPLY, BACKUP_APPLY, INSPECT):
             try:
                 self.modified_data = open(self.modified_file, 'rb').read()
             except:
@@ -129,7 +134,7 @@ class IPS(object):
 
         # File object containing the IPS patch
         try:
-            if self.cmd in ('-a', '-ab', INSPECT):
+            if self.cmd in (APPLY, BACKUP_APPLY, INSPECT):
                 self.patch_file_obj = bytearray(open(self.patch_file, 'rb').read())
             else:
                 self.patch_file_obj = open(self.patch_file, 'wb')
@@ -137,7 +142,7 @@ class IPS(object):
             print(f'> Cannot read {self.patch_file}.\n')
             sys.exit(1)
 
-        if self.cmd not in ('-a', '-ab', INSPECT):
+        if self.cmd not in (APPLY, BACKUP_APPLY, INSPECT):
             # The IPS file format has a size limit of 16MB
             if len(self.modified_data) > self.FILE_LIMIT:
                 print('File is too large! ( Max 16MB )\nThe patch could be broken!')
@@ -176,7 +181,7 @@ class IPS(object):
         if inspect:
             print(f'Patch data for {self.patch_file}:\n')
 
-        if self.cmd == '-ab':
+        if self.cmd == BACKUP_APPLY:
             try:
                 org_file_cont = bytearray(open(file_to_patch, 'rb').read())
                 open(self.modified_file, 'wb').write(org_file_cont)
@@ -348,19 +353,19 @@ if __name__ == '__main__':
 
     if args.a:
         original_file, patch_file = args.a
-        ips = IPS('-a', original_file, '', patch_file)
+        ips = IPS(APPLY, original_file, '', patch_file)
         ips()
 
     elif args.ab:
         original_file, patch_file = args.ab
         patched_file_name = args.outputFile or f'Patched_{original_file}'
-        ips = IPS('-ab', original_file, patched_file_name, patch_file)
+        ips = IPS(BACKUP_APPLY, original_file, patched_file_name, patch_file)
         ips()
 
     elif args.c:
         original_file, modified_file = args.c
         patch_file = output_file or f'{modified_file}.ips'
-        ips = IPS('-c', original_file, modified_file, patch_file)
+        ips = IPS(CREATE, original_file, modified_file, patch_file)
         ips()
 
     elif args.inspect:

--- a/lipx.py
+++ b/lipx.py
@@ -13,7 +13,7 @@ _ntuple_diskusage = collections.namedtuple('usage', 'total used free')
 APPLY = '-a'
 BACKUP_APPLY = '-ab'
 CREATE = '-c'
-INSPECT = 'inspect'
+INSPECT = '-i'
 
 
 def disk_usage(path):

--- a/lipx.py
+++ b/lipx.py
@@ -222,7 +222,7 @@ class IPS(object):
                 a += 1
 
                 if inspect:
-                    print(format_patch(offset, size, repeat.to_bytes(1, 'big'), rle_size))
+                    print(format_patch(offset, size, bytearray(repeat.to_bytes(1, 'big')), rle_size))
                 else:
                     for x in range(rle_size):
                         try:

--- a/lipx.py
+++ b/lipx.py
@@ -201,7 +201,7 @@ class IPS(object):
             size = get_uint16(self.patch_file_obj, a)
             a += 2
 
-            if info and size:
+            if inspect and size:
                 print(format_patch(offset, size, self.patch_file_obj[a:a+size]))
 
             if size == 0:
@@ -217,7 +217,7 @@ class IPS(object):
                 repeat = self.patch_file_obj[a]
                 a += 1
 
-                if info:
+                if inspect:
                     print(format_patch(offset, size, repeat.to_bytes(1, 'big'), rle_size))
                 else:
                     for x in range(rle_size):
@@ -233,7 +233,7 @@ class IPS(object):
 
                 # Normal packet, copy from patch to file
                 for x in range(size):
-                    if info:
+                    if inspect:
                         a += 1
                     else:
                         try:
@@ -242,7 +242,7 @@ class IPS(object):
                         except:
                             print('> Error - Unable to parse the patch!')
                             sys.exit(1)
-        if info:
+        if inspect:
             return True
 
         try:
@@ -341,7 +341,7 @@ if __name__ == '__main__':
     parser.add_argument('-a', help='Apply patch', nargs=2, metavar=('originalFile', 'patchFile'))
     parser.add_argument('-ab', help='Create a copy and apply the patch - original is untouched', nargs=2, metavar=('originalFile', 'patchFile'))
     parser.add_argument('-c', help='Create IPS patch', nargs=2, metavar=('originalFile', 'modifiedFile'))
-    parser.add_argument('-i', '--inspect', help='Inspect the changes made by an IPS file')
+    parser.add_argument('-i', '--inspect', help='Inspect the changes made by an IPS file', metavar='patchFile')
     parser.add_argument('outputFile', help='Optional outputFile', nargs='?')
     args = parser.parse_args()
 

--- a/lipx.py
+++ b/lipx.py
@@ -30,7 +30,7 @@ def get_uint24(data, index):
     return int((data[index] << 16) | (data[index + 1] << 8) | data[index + 2])
 
 
-# Helper function to display patch data in INFO mode
+# Helper function to display patch data in INSPECT mode
 def format_patch(offset, size, data, rle=0):
     if (offset ^ size) & 1:
         data.append(0)
@@ -75,7 +75,7 @@ class IPS(object):
     def __call__(self):
         ret = False
 
-        print('### Lipx v' + VERSION + ' - Linux IPS Tool ###\n')
+        print(f'### Lipx v{VERSION} - Linux IPS Tool ###\n')
 
         self._setup_files()
 
@@ -116,7 +116,7 @@ class IPS(object):
             try:
                 self.original_data = open(self.original_file, 'rb').read()
             except:
-                print("> Cannot read %s" % self.original_file + '.\n')
+                print(f'> Cannot read {self.original_file}.\n')
                 sys.exit(1)
 
         # File object containing the modified ROM data (To create IPS patch)
@@ -124,7 +124,7 @@ class IPS(object):
             try:
                 self.modified_data = open(self.modified_file, 'rb').read()
             except:
-                print("> Cannot read %s" % self.modified_file + '.\n')
+                print(f'> Cannot read {self.modified_file}.\n')
                 sys.exit(1)
 
         # File object containing the IPS patch
@@ -134,14 +134,13 @@ class IPS(object):
             else:
                 self.patch_file_obj = open(self.patch_file, 'wb')
         except:
-            print("> Cannot read %s" % self.patch_file + '.\n')
+            print(f'> Cannot read {self.patch_file}.\n')
             sys.exit(1)
 
         if self.cmd not in ('-a', '-ab', INSPECT):
             # The IPS file format has a size limit of 16MB
             if len(self.modified_data) > self.FILE_LIMIT:
                 print('File is too large! ( Max 16MB )\nThe patch could be broken!')
-
         return True
 
     def write_record(self, record_data, overide_size=0):
@@ -182,7 +181,7 @@ class IPS(object):
                 org_file_cont = bytearray(open(file_to_patch, 'rb').read())
                 open(self.modified_file, 'wb').write(org_file_cont)
             except:
-                print('> Error - Cannot create %s' % self.modified_file)
+                print(f'> Error - Cannot create {self.modified_file}')
                 sys.exit(1)
 
             file_to_patch = self.modified_file
@@ -252,7 +251,7 @@ class IPS(object):
             print('> Error - Cannot write to file!')
             sys.exit(1)
 
-        print('> Success - Patch applied to %s' % file_to_patch)
+        print(f'> Success - Patch applied to {file_to_patch}')
 
         return True
 
@@ -307,7 +306,7 @@ class IPS(object):
                 # Records have a max size of 0xFFFF as the size header is a short
                 # Check our current position and if we at the max size end the record and start a new one
                 if len(record) == self.RECORD_LIMIT - 1:
-                    print("Truncating overlong record: %s %s" % (len(record), hex(len(record))))
+                    print(f'Truncating overlong record: {len(record)} {hex(len(record))}')
 
                     record_begun = False
                     record.append(self.modified_data[pos])
@@ -331,7 +330,7 @@ class IPS(object):
         self.patch_size += len(self.EOF_ASCII)
         self.patch_file_obj.close()
 
-        print("> Success - Patch file: %s" % self.patch_file)
+        print(f'> Success - Patch file: {self.patch_file}')
 
         return True
 

--- a/lipx.py
+++ b/lipx.py
@@ -47,9 +47,13 @@ def get_uint24(data, index):
 
 # Helper function to display patch data in INFO mode
 def format_patch(offset, size, data, rle=0):
-    data = data.hex('.')
+    if (offset ^ size) & 1:
+        data.append(0)
+        data = data.hex(' ', 2)[:-2]
+    else:
+        data = data.hex(' ', 2)
     repeat = f' REPEAT x {rle}' if rle else ''
-    return f'{hex(offset)[2:].zfill(6)} ({str(size).zfill(2)}): {data}{repeat}'
+    return f'{hex(offset)[2:].zfill(6)} ({str(size).zfill(2)}): {"  " * (offset & 1) + data}{repeat}'
 
 
 class IPS(object):


### PR DESCRIPTION
This builds on the argparse changes I made in #10 . This is the feature I wanted to add and use, but I got carried away refactoring because it was harder to add another option cleanly without `argparse`.

This PR adds an inspect mode:

```
  -i patchFile, --inspect patchFile
                        Inspect the changes made by an IPS file

```

Example usage and output:
`$ ./lipx.py -i demo.ips`

```
### Lipx v1.2 - Linux IPS Tool ###

Patch data for demo.ips:

00046d (01):   36
0006b8 (03): 0521 38
0006bc (03): 1404 34
0006c4 (03): 2111 26
00125c (01): 66
0012c9 (01):   66
001a26 (01): 02
002625 (01):   02
002ace (01): ff
002ad2 (05): ff00 aaaa aa
002ad9 (01):   ff
002adb (01):   00
0035e3 (03):   3f 2a15
003604 (06): 0521 3814 0434
003610 (03): 2111 26
003da4 (01): 66
003db3 (01):   66
004370 (16): 0024 5a85 8142 2418 0000 247e 7e3c 1800
004395 (03):   07 0f1f
00439d (07):   00 0000 3f3d 7f7f
0043a8 (02): 0000
0043ab (01):   0f
0043b1 (03):   00 0000
0043b5 (01):   0e
0043b9 (05):   0e 1e1c 1f00
0043c5 (03):   c0 e0f0
0043cd (05):   00 0000 f0f8
0043d3 (07):   fc f4e6 e2c4 0000
0043db (02):   e0 40
0043e0 (04): 0000 0c0c
...
```
The number in brackets is the (decimal) count of bytes at that location.

I've tried to keep the output similar to the output of `xxd`, and also the layout and terminology of https://github.com/kylon/IPS-Viewer

The jagged offsets in the hex output are for maintaining word alignment, which I found helpful when comparing in other hex editors.

I'm using this for debugging some patches. I hope it's useful to others. I'll happily take feedback on this as I'm new to  working with IPS files, and I have only tested with my patches.

There's probably more refactoring that could be done in the IPS class around modes, but everything is functional as is.